### PR TITLE
Pieces + CSC Lookup Table Refactor

### DIFF
--- a/pychess/ai_engine.py
+++ b/pychess/ai_engine.py
@@ -17,21 +17,17 @@ class chess_ai:
     get the value of each piece
     '''
     def minimax_white(self, game_state, depth, alpha, beta, maximizing_player, player_color):
+        csc_lookup = {
+            (True, 0): 5000000,
+            (True, 1): -5000000,
+            (True, 2): 100,
+            (False, 1): 5000000,
+            (False, 0): -5000000,
+            (False, 2): 100
+        }
         csc = game_state.checkmate_stalemate_checker()
-        if maximizing_player:
-            if csc == 0:
-                return 5000000
-            elif csc == 1:
-                return -5000000
-            elif csc == 2:
-                return 100
-        elif not maximizing_player:
-            if csc == 1:
-                return 5000000
-            elif csc == 0:
-                return -5000000
-            elif csc == 2:
-                return 100
+        if (maximizing_player, csc) in csc_lookup:
+            return csc_lookup[(maximizing_player, csc)]
 
         if depth <= 0 or csc != 3:
             return self.evaluate_board(game_state, Player.PLAYER_1)
@@ -74,21 +70,17 @@ class chess_ai:
                 return min_evaluation
 
     def minimax_black(self, game_state, depth, alpha, beta, maximizing_player, player_color):
+        csc_lookup = {
+            (True, 0): 5000000,
+            (True, 1): -5000000,
+            (True, 2): 100,
+            (False, 1): 5000000,
+            (False, 0): -5000000,
+            (False, 2): 100
+        }
         csc = game_state.checkmate_stalemate_checker()
-        if maximizing_player:
-            if csc == 1:
-                return 5000000
-            elif csc == 0:
-                return -5000000
-            elif csc == 2:
-                return 100
-        elif not maximizing_player:
-            if csc == 0:
-                return 5000000
-            elif csc == 1:
-                return -5000000
-            elif csc == 2:
-                return 100
+        if (maximizing_player, csc) in csc_lookup:
+            return csc_lookup[(maximizing_player, csc)]
 
         if depth <= 0 or csc != 3:
             return self.evaluate_board(game_state, Player.PLAYER_2)
@@ -129,6 +121,7 @@ class chess_ai:
                 return best_possible_move
             else:
                 return min_evaluation
+
 
     def evaluate_board(self, game_state, player):
         evaluation_score = 0

--- a/pychess/bishop.py
+++ b/pychess/bishop.py
@@ -1,56 +1,28 @@
-
 from enums import Player
 from piece import Piece
 
-
 class Bishop(Piece):
-    # Get moves
     def get_valid_piece_moves(self, game_state):
-        _peaceful_moves = []
-        _piece_takes = []
+        moves = []
+        current_row, current_col = self.get_row_number(), self.get_col_number()
 
-        def check_new_position(new_row, new_col):
-            # when the square is empty
-            if game_state.get_piece(new_row, new_col) is Player.EMPTY:
-                _peaceful_moves.append((new_row, new_col))
-            # when the square contains an opposing piece
-            elif game_state.is_valid_piece(new_row, new_col) and \
-                    not game_state.get_piece(new_row, new_col).is_player(self.get_player()):
-                _piece_takes.append((new_row, new_col))
-                self._breaking_point = True
-            else:
-                self._breaking_point = True
-        
-        # Left up of the bishop
-        _up, _left = 1, 1
-        self._breaking_point = False
-        while self.get_col_number() - _left >= 0 and self.get_row_number() - _up >= 0 and not self._breaking_point:
-            check_new_position(self.get_row_number() - _up, self.get_col_number() - _left)
-            _up += 1
-            _left += 1
+        def check_new_position(row_step, col_step):
+            row, col = current_row + row_step, current_col + col_step
+            while 0 <= row < 8 and 0 <= col < 8:
+                piece = game_state.get_piece(row, col)
+                if piece is Player.EMPTY:
+                    moves.append((row, col))
+                elif game_state.is_valid_piece(row, col) and not piece.is_player(self.get_player()):
+                    moves.append((row, col))
+                    break
+                else:
+                    break
+                row += row_step
+                col += col_step
 
-        # Right up of the bishop
-        _up, _right = 1, 1
-        self._breaking_point = False
-        while self.get_col_number() + _right < 8 and self.get_row_number() - _up >= 0 and not self._breaking_point:
-            check_new_position(self.get_row_number() - _up, self.get_col_number() + _right)
-            _up += 1
-            _right += 1
+        check_new_position(-1, -1)  
+        check_new_position(-1, 1)   
+        check_new_position(1, -1)   
+        check_new_position(1, 1)   
 
-        # Down left of the bishop
-        _down, _left = 1, 1
-        self._breaking_point = False
-        while self.get_col_number() - _left >= 0 and self.get_row_number() + _down < 8 and not self._breaking_point:
-            check_new_position(self.get_row_number() + _down, self.get_col_number() - _left)
-            _down += 1
-            _left += 1
-
-        # Down right of the bishop
-        _down, _right = 1, 1
-        self._breaking_point = False
-        while self.get_col_number() + _right < 8 and self.get_row_number() + _down < 8 and not self._breaking_point:
-            check_new_position(self.get_row_number() + _down, self.get_col_number() + _right)
-            _down += 1
-            _right += 1
-        
-        return _peaceful_moves + _piece_takes
+        return moves

--- a/pychess/knight.py
+++ b/pychess/knight.py
@@ -1,29 +1,23 @@
-
 from enums import Player
 from piece import Piece
 
-
 class Knight(Piece):
-    # Get moves
     def get_valid_piece_moves(self, game_state):
         _peaceful_moves = []
         _piece_takes = []
 
-        row_change = [-2, -2, -1, -1, +1, +1, +2, +2]
-        col_change = [-1, +1, -2, +2, -2, +2, +1, -1]
+        moves = [(-2, -1), (-2, 1), (-1, -2), (-1, 2), (1, -2), (1, 2), (2, -1), (2, 1)]
 
-        for i in range(0, 8):
-            new_row = self.get_row_number() + row_change[i]
-            new_col = self.get_col_number() + col_change[i]
+        for move in moves:
+            new_row = self.get_row_number() + move[0]
+            new_col = self.get_col_number() + move[1]
 
-            if not 0 <= new_row < 8 or not 0 <= new_col < 8:
-                continue
+            if 0 <= new_row < 8 and 0 <= new_col < 8:
+                evaluating_square = game_state.get_piece(new_row, new_col)
+                
+                if evaluating_square == Player.EMPTY:
+                    _peaceful_moves.append((new_row, new_col))
+                elif not evaluating_square.is_player(self.get_player()):
+                    _piece_takes.append((new_row, new_col))
 
-            evaluating_square = game_state.get_piece(new_row, new_col)
-            
-            if evaluating_square == Player.EMPTY:
-                _peaceful_moves.append((new_row, new_col))
-            elif not evaluating_square.is_player(self.get_player()):
-                _piece_takes.append((new_row, new_col))
-        
         return _peaceful_moves + _piece_takes

--- a/pychess/pawn.py
+++ b/pychess/pawn.py
@@ -4,32 +4,30 @@ from piece import Piece
 
 
 class Pawn(Piece):
-    # Get moves
     def get_valid_piece_moves(self, game_state):
-        _peaceful_moves = []
-        _piece_takes = []
+        if self.is_player(Player.PLAYER_1):
+            original_row_num, move_one_row, move_two_row = 1, 1, 2
+        else:
+            original_row_num, move_one_row, move_two_row = 6, -1, -2
 
-        original_row_num, move_one_row, move_two_row = (1, 1, 2) if self.is_player(Player.PLAYER_1) else (6, -1, -2)
         opposing_player = Player.PLAYER_1 if self.is_player(Player.PLAYER_2) else Player.PLAYER_2
 
-        # when the square right below the starting_square is empty
-        if game_state.get_piece(self.get_row_number() + move_one_row, self.get_col_number()) == Player.EMPTY:
-            _peaceful_moves.append((self.get_row_number() + move_one_row, self.get_col_number()))
-            # when the pawn has not been moved yet
-            if self.get_row_number() == original_row_num and game_state.get_piece(self.get_row_number() + move_two_row,
-                                                                    self.get_col_number()) == Player.EMPTY:
-                _peaceful_moves.append((self.get_row_number() + move_two_row, self.get_col_number()))
-        
-        # when the square to the bottom left of the starting_square has a black piece
-        if game_state.is_valid_piece(self.get_row_number() + move_one_row, self.get_col_number() - 1) and \
-                game_state.get_piece(self.get_row_number() + move_one_row, self.get_col_number() - 1).is_player(opposing_player):
-            _piece_takes.append((self.get_row_number() + move_one_row, self.get_col_number() - 1))
-        # when the square to the bottom right of the starting_square has a black piece
-        if game_state.is_valid_piece(self.get_row_number() + move_one_row, self.get_col_number() + 1) and \
-                game_state.get_piece(self.get_row_number() + move_one_row, self.get_col_number() + 1).is_player(opposing_player):
-            _piece_takes.append((self.get_row_number() + move_one_row, self.get_col_number() + 1))
-        # en passant (TODO: FIX)
-        if game_state.can_en_passant(self.get_row_number(), self.get_col_number()):
-            _piece_takes.append((self.get_row_number() + move_one_row, game_state.previous_piece_en_passant()[1]))
+        current_row, current_col = self.get_row_number(), self.get_col_number()
+
+        next_square = game_state.get_piece(current_row + move_one_row, current_col)
+        next_next_square = game_state.get_piece(current_row + move_two_row, current_col)
+
+        _peaceful_moves = [(current_row + move_one_row, current_col)] if next_square == Player.EMPTY else []
+        if current_row == original_row_num and next_next_square == Player.EMPTY:
+            _peaceful_moves.append((current_row + move_two_row, current_col))
+
+        _piece_takes = []
+        for col in (current_col - 1, current_col + 1):
+            if game_state.is_valid_piece(current_row + move_one_row, col) and \
+                    game_state.get_piece(current_row + move_one_row, col).is_player(opposing_player):
+                _piece_takes.append((current_row + move_one_row, col))
+
+        if game_state.can_en_passant(current_row, current_col):
+            _piece_takes.append((current_row + move_one_row, game_state.previous_piece_en_passant()[1]))
 
         return _peaceful_moves + _piece_takes


### PR DESCRIPTION
I made some small refactors to the bishop, pawn, and knight. Most of them avoid repeating function calls, use list comprehension, and implement a CSC Lookup Table instead of an elif (or switch) type statement. Cool stuff with the Alpha-Beta minimax implementation!

I've tested this program both on Windows 10 (PC) and EndeavorOS Cassini Nova R3 (Laptop) and it all seems to be in order! 

PS: I haven't found a way to fix the isinstance bug without a major refactor. I would imagine it would be something along these lines:

```python
if evaluating_piece is None:
    _peaceful_moves.append((new_row, new_col))
elif not evaluating_piece.is_player(self.get_player()):
    _piece_takes.append((new_row, new_col))
```
The isinstance check can be avoided by ensuring that your game_state.get_piece() function always returns a Piece object or None if no piece is present. Then you can check if evaluating_piece is None or if it belongs to the opposite player, which would require some refactoring of the is_player() itself. 

Apologies if this pull request is sudden, I got bored in my dorm room and found your chess engine as well as the motivating blog behind it to be quite interesting. Your story is nothing less than incredible and I enjoyed reading your blog thoroughly!

Regards,

Ty C '27

